### PR TITLE
Bug fix missing public ip parameter

### DIFF
--- a/bin/ecs-task-runner
+++ b/bin/ecs-task-runner
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 'use strict'
 
-const _             = require('lodash'),
-      async         = require('async'),
-      ecsTaskRunner = require('../'),
-      colors        = require('colors'),
-      yargs         = require('yargs');
+const
+  ecsTaskRunner = require('../'),
+  yargs = require('yargs');
 
 const argv = yargs
   .option('cluster', {
@@ -34,8 +32,8 @@ const argv = yargs
     array: true,
     describe: 'key=value   Pass an additional environment variable to the container',
     coerce: opts => {
-      return _.map(opts, item => {
-        let pieces = _.split(item, '=', 2);
+      return opts.map(item => {
+        let pieces = item.split('=');
         return { name: pieces[0], value: pieces[1] };
       })
     }
@@ -81,7 +79,7 @@ const options = {
   securityGroups: argv.securityGroups
 };
 
-ecsTaskRunner(options, function(err, stream) {
+ecsTaskRunner(options, function (err, stream) {
   if (err) throw err;
 
   stream.on('error', (err) => {

--- a/lib/taskrunner.js
+++ b/lib/taskrunner.js
@@ -3,14 +3,14 @@
 const AWS = require('aws-sdk');
 
 module.exports = {
-  makeCmd: function(options) {
+  makeCmd: function (options) {
     return [
       'sh', '-c',
       `sh -c "${options.cmd}"; EXITCODE=$?; echo "TASK FINISHED: $(echo -n ${options.endOfStreamIdentifier} | base64), EXITCODE: $EXITCODE"`
     ];
   },
 
-  run: function(options, cb) {
+  run: function (options, cb) {
     const ecs = new AWS.ECS();
     const params = {
       cluster: options.clusterArn,
@@ -34,12 +34,14 @@ module.exports = {
       params.overrides.containerOverrides[0].environment = options.env;
     }
 
-    if (options.subnets !== undefined || options.securityGroups !== undefined || options.assignPublicIp !== undefined) {
-      params.networkConfiguration = { awsvpcConfiguration: { } };
-    }
-
-    if (options.assignPublicIp !== undefined) {
-      params.networkConfiguration.awsvpcConfiguration.assignPublicIp = options.assignPublicIp? 'ENABLED':'DISABLED';
+    // Since yargs' boolean argument type will always be true or false, we can't distinguish between assignPublicIp not
+    // being set and it being false. Therefore we'll always set it, as long as we have an awsvpcConfiguration block.
+    if (options.subnets !== undefined || options.securityGroups !== undefined || options.assignPublicIp === true) {
+      params.networkConfiguration = {
+        awsvpcConfiguration: {
+          assignPublicIp: options.assignPublicIp ? 'ENABLED' : 'DISABLED'
+        }
+      };
     }
 
     if (options.subnets !== undefined) {
@@ -53,7 +55,7 @@ module.exports = {
     ecs.runTask(params, cb);
   },
 
-  stop: function(options, cb) {
+  stop: function (options, cb) {
     const ecs = new AWS.ECS();
     const params = {
       cluster: options.clusterArn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,11 @@
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-task-runner",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "async": "^2.6.1",
         "aws-sdk": "^2.254.1",
-        "colors": "^1.3.0",
         "lodash": "^4.17.11",
         "moment": "^2.22.2",
         "randomstring": "^1.1.5",
@@ -452,14 +451,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
-      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/commander": {
       "version": "2.15.1",
@@ -2949,11 +2940,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "colors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
-      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
     },
     "commander": {
       "version": "2.15.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-task-runner",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Run a task on ecs and stream logs from Cloudwatch Logs to the console",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "async": "^2.6.1",
     "aws-sdk": "^2.254.1",
-    "colors": "^1.3.0",
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "randomstring": "^1.1.5",


### PR DESCRIPTION
I suspect #4 broke things when it introduced some new parameters to allow AWSVPC networking to be used, as the error we keep on getting is relating to subnets not being defined. The root cause is that yargs' boolean type will default to false, whereas the array type will default to undefined.

This means that we can never compare to undefined and get the expected result, so judging whether we wanted AWSVPC networking mode or not, and whether we had the right set of parameters to satisfy that, was always flawed, and didn't configure the task definition correctly.

I've fixed that, and also started pulling out some unnecessary pre-ES6-isms but it's too big a mess to do in one PR (and too unrelated). We still depend on lodash and async although we really don't need to, but that's a bigger job for another day.