### PR TITLE
Bump minor version (to 0.2.0) for dependency updates.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-task-runner",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Run a task on ecs and stream logs from Cloudwatch Logs to the console",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Quite a lot of security-related updates were outstanding - I've merged all of these in and it's time to bump the version.