### PR TITLE
[INF-2535] Remove unnecessary dependencies.

### DIFF
--- a/lib/log-stream.js
+++ b/lib/log-stream.js
@@ -1,31 +1,18 @@
 'use strict'
 
-const _ = require('lodash');
 const { CloudWatchLogs } = require("@aws-sdk/client-cloudwatch-logs");
-const moment = require('moment');
 const Readable = require('stream').Readable;
 
 const region = process.env.AWS_DEFAULT_REGION || 'us-east-1';
-
-// Take cloudwatchlogs.getLogEvents data and
-// return logs events as strings
-function renderLogEvents(data) {
-  const lines = _.map(data.events, function (event) {
-    return moment(event.timestamp).format('Y-MM-DD H:m:ss ZZ').cyan + ' ' + event.message;
-  });
-
-  return lines.join("\n");
-}
 
 class LogStream extends Readable {
   constructor(options) {
     options.objectMode = true;
     super(options);
 
-    this.options = _.defaults(options, {
-      durationBetweenPolls: 1000,
-      timeoutBeforeFirstLogs: 300 * 1000
-    });
+    this.options = options;
+    this.options.durationBetweenPolls = options.durationBetweenPolls || 1000;
+    this.options.timeoutBeforeFirstLogs = options.timeoutBeforeFirstLogs || 300 * 1000;
 
     this.eventBuffer = [];
     this.pending = false;
@@ -68,7 +55,7 @@ class LogStream extends Readable {
         // version of eof identifiter so that listener doesn't accidentally
         // catch the eof identifier if container echoes out running command.
         const endOfStreamIdentifierBase64 = Buffer.from(this.options.endOfStreamIdentifier).toString('base64');
-        const endEvent = _.find(data.events, (event) => event.message.includes(endOfStreamIdentifierBase64));
+        const endEvent = data.events.find((event) => event.message.includes(endOfStreamIdentifierBase64));
 
         if (this.stopRequested) {
           this.exitCode = 130;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.451.0",
         "@aws-sdk/client-ecs": "^3.451.0",
-        "async": "^2.6.1",
-        "lodash": "^4.17.11",
-        "moment": "^2.22.2",
         "randomstring": "^1.1.5",
         "stream-combiner": "^0.2.2",
         "yargs": "^17.7.1"
@@ -32,6 +29,9 @@
         "expect.js": "^0.3.1",
         "mocha": "^10.2.0",
         "sinon": "^5.1.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1460,14 +1460,6 @@
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/aws-sdk-client-mock": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.0.tgz",
@@ -2806,7 +2798,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -3060,14 +3053,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -5060,14 +5045,6 @@
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
-    "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
     "aws-sdk-client-mock": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.0.tgz",
@@ -6094,7 +6071,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -6283,11 +6261,6 @@
           "dev": true
         }
       }
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-task-runner",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.451.0",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.451.0",
     "@aws-sdk/client-ecs": "^3.451.0",
-    "async": "^2.6.1",
-    "lodash": "^4.17.11",
-    "moment": "^2.22.2",
     "randomstring": "^1.1.5",
     "stream-combiner": "^0.2.2",
     "yargs": "^17.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Run a task on ecs and stream logs from Cloudwatch Logs to the console",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This mainly cleans up a few dependencies that aren't really necessary like lodash and async that were only used in a handful of places and could be replaced with native ES6 mechanisms.

The async.waterfall call is a bit fiddly to refactor into promise chaining but appears to work fine.