### PR TITLE
[INF-2994] Bump to 0.3.4 for security updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-task-runner",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.451.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Run a task on ecs and stream logs from Cloudwatch Logs to the console",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
https://github.com/bugcrowd/ecs-task-runner/security/dependabot/33 among others.