### PR TITLE
[CHORE] Bump version for dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-task-runner",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.451.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-task-runner",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Run a task on ecs and stream logs from Cloudwatch Logs to the console",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
There's at least one runtime dependency bump here, so let's release a new patch version - 0.3.5.