### PR TITLE
Fix pending state being used incorrectly, ignore ThrottlingException error, accept more options

### DIFF
--- a/bin/ecs-task-runner
+++ b/bin/ecs-task-runner
@@ -61,6 +61,16 @@ const argv = yargs
     describe: 'Security groups network configuration (awsvpc configuration)',
     type: 'array'
   })
+  .option('duration-between-polls', {
+    describe: 'Duration between logs polls',
+    type: 'number',
+    default: 1000
+  })
+  .option('timeout-before-first-logs', {
+    describe: 'Timeout before first logs',
+    type: 'number',
+    default: 300 * 1000
+  })
   .help()
   .wrap(yargs.terminalWidth())
   .argv;

--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ module.exports = function (options, cb) {
       const logs = new LogStream({
         logGroup: logOptions['awslogs-group'],
         logStream: `${logOptions['awslogs-stream-prefix']}/${options.containerName}/${taskId}`,
-        endOfStreamIdentifier: endOfStreamIdentifier
+        endOfStreamIdentifier: endOfStreamIdentifier,
+        durationBetweenPolls: options.durationBetweenPolls,
+        timeoutBeforeFirstLogs: options.timeoutBeforeFirstLogs
       });
 
       const stream = combiner(logs, formatter);

--- a/lib/log-stream.js
+++ b/lib/log-stream.js
@@ -75,7 +75,6 @@ class LogStream extends Readable {
       .catch((err) => {
         // Dismiss log stream not found. Log stream won't exist
         // until container starts logging
-        console.log("ERROR:", err)
         if (err && 'ResourceNotFoundException' === err.name) return next();
         // Dismiss log stream throttling error. These API calls have a hard limit,
         // and they don't qualify for a limit increase

--- a/lib/log-stream.js
+++ b/lib/log-stream.js
@@ -75,7 +75,11 @@ class LogStream extends Readable {
       .catch((err) => {
         // Dismiss log stream not found. Log stream won't exist
         // until container starts logging
+        console.log("ERROR:", err)
         if (err && 'ResourceNotFoundException' === err.name) return next();
+        // Dismiss log stream throttling error. These API calls have a hard limit,
+        // and they don't qualify for a limit increase
+        if (err && 'ThrottlingException' === err.name) return next();
         if (err) return process.nextTick(() => this.emit('error', err));
       });
   }

--- a/lib/log-stream.js
+++ b/lib/log-stream.js
@@ -33,15 +33,18 @@ class LogStream extends Readable {
     };
 
     let next = (_err, _data) => {
+      this.pending = false;
       setTimeout(this._read.bind(this), this.options.durationBetweenPolls);
     };
 
-    this.pending = false;
     this.cloudwatchlogs.getLogEvents(params)
       .then((data) => {
-        if (data && data.events.length > 0) {
+        if (data) {
+          if (!this.logsReceived) {
+            this.logsReceived = data.events.length > 0
+          }
+
           this.nextToken = data.nextForwardToken;
-          this.logsReceived = true;
           data.events.forEach((event) => this.eventBuffer.push(event));
         }
 


### PR DESCRIPTION
Hi!

This PR fixes two issues:

1. we noticed that sometimes we could see some log records repeated, like so:
    ```
    Processed: 500/407210 (took 0.84s)
    Processed: 26000/407210 (took 0.56s)
    Processed: 53500/407210 (took 0.51s)
    Processed: 53500/407210 (took 0.51s) <- double
    Processed: 98500/407210 (took 0.67s)
    Processed: 123500/407210 (took 0.53s)
    Processed: 123500/407210 (took 0.53s)
    Processed: 123500/407210 (took 0.53s) <- triple
    Processed: 152000/407210 (took 0.47s)
    ```
   it was caused by the pending key not being set correctly, so there was some sort of race condition;
2.  because of the race condition we could get `ThrottlingException`, get logs calls have a hard limit, and they don't qualify for a limit increase in AWS, so having two, three... tasks running simultaneously could cause the error quickly, the easiest way just to ignore it as it do not affect anything.

I've also added configuration for `durationBetweenPolls` and `timeoutBeforeFirstLogs`